### PR TITLE
Reuse saved .configdb when re-running configdb

### DIFF
--- a/Morsulus-Search/scripts/configdb.b.pl
+++ b/Morsulus-Search/scripts/configdb.b.pl
@@ -15,7 +15,7 @@ $_ = &input ('');
 # Get old config values, if available.
 
 $conf_file = '.configdb';
-&read_config_file ($conf_file);
+%config = &read_config_file ($conf_file);
 
 #=================================#
 # Set database server parameters. #
@@ -118,7 +118,8 @@ $DatabaseServerPath = &get_filepath ('XDatabaseServerPathX',
 # Set $LogFileName.
 
 logfilename:
-$LogFileName = '/tmp/dbserver.log';
+$LogFileName = $config{'XLogFileNameX'};
+$LogFileName = '/tmp/dbserver.log' if ($LogFileName eq '');
 $LogFileName = "$cwd/$LogFileName" if ($LogFileName =~ m#^[^/]#);
 print "\nPath for database server log:\n[$LogFileName] ";
 $LogFileName = &input ($LogFileName);


### PR DESCRIPTION
Although configdb does write its configuration parameters out to .configdb, it didn’t load the previously-saved values the next time it was run, so you had to re-enter them every time you run configdb.

This attached patch fixes this problem, so that you can re-run perl config.web -f and perl configdb -f in succession without having to re-key any configuration options.