### PR TITLE
Update welcome text on search form index page

### DIFF
--- a/Morsulus-Search/scripts/index.html
+++ b/Morsulus-Search/scripts/index.html
@@ -3,65 +3,31 @@
 <base href="XXSearchMenuUrlXX">XXHeadXX
 </head><body>
 
-<h2>Search Forms for the SCA Armorial</h2>
-<p>
-You can find currently-registered armory starting at
-the <a href="XXIndexDirUrlXX/index.html">index for the on-line SCA Ordinary</a>.
-If you are trying to look armory by its description, or doing conflict
-checking, you almost certainly want to start here.
-
-<p>
-There are also six search forms available:
-<ol>
-<li>
-A <a href="XXNameSearchUrlXX">Name Search Form</a>
-which allows you to search the SCA Armorial database for items
-associated with a particular name.  This form is fast and simple,
-but not very powerful.  For instance, your search will
-fail if you don't type the name exactly right.
-<p>
-<li>
-An <a href="XXDescSearchUrlXX">
-Armory Description Search Form</a> which allows you to search for
-registered items that appear under a particular heading in the
-<a href="XXIndexDirUrlXX/index.html">SCA Ordinary</a>.  This form
-is difficult to use because you must know how the headings are
-coded in the database.  This difficulty will be corrected
-eventually, but for now the 
-<a href="XXIndexDirUrlXX/index.html">SCA Ordinary</a> is much
-more useful.
-<p>
-<li>
-A <a href="XXNpSearchUrlXX">
-Name Pattern Search Form</a> which allows you to search for
-items associated with a name, even if you don't know
-the exact spelling of the name.  Very useful.
-<p>
-<li>
-A <a href="XXBpSearchUrlXX">
-Blazon Pattern Search Form</a> which allows you to search for
-blazons containing particular words or text patterns. Please do 
-not use this for conflict checking. Use the Ordinary or the Armory
-Description Search Form. 
-<p>
-<li>
-A <a href="XXDateSearchUrlXX">
-Date/Kingdom Search Form</a> which allows you to search for registrations
-during a particular time-period or via a particular kingdom.
-NOTE: This form is broken broken broken. Don't bother trying it until it
-gets fixed. Watch for this message to go away.
-<p>
-<li>
-A <a href="XXComplexSearchUrlXX">
-Complex Search Form</a> which allows you to do sophisticated
-searches on the database by combining the results of multiple
-searches.  This form is tricky to use, because
-there are more things to configure.
-<p>
-</ol>
-<p>
-You can also find currently-registered armory using
-the <a href="XXIndexDirUrlXX/index.html">on-line SCA Ordinary</a>.
+    <h2>Welcome to the Ordinary &amp; Armorial of the SCA</h2>
+    <p>
+        This O&amp;A is a web-based searchable database of the names and armory registered by <a href="http://heraldry.sca.org">the College of Arms</a> of <a href="http://sca.org">the Society for Creative Anachronism</a>.
+    </p>
+    <p>
+        Use these tools to find registered names and armory:
+    </p>
+    
+    <ul class="generous"> <style> ul.generous li { margin-top: 1em; } </style>
+    <li>
+        <a href="XXIndexDirUrlXX/"><strong>The Ordinary</strong></a> provides an index of currently-registered armory based on a description of the field or charges they contain. The Ordinary is useful for finding armory based on a picture, or for conflict-checking new armory submissions. The Ordinary works in conjunction with the <a href="XXDescSearchUrlXX"><strong>Armory Description Search Form</strong></a> which shows registered items that appear under a particular heading.
+    </li>
+    <li>
+        <a href="XXNpSearchUrlXX"><strong>The Name Pattern Search Form</strong></a> finds items associated with a name. The pattern feature matches partial names and supports wildcards, so you can use it even if you don't know the exact spelling of the full name. There's also an exact-match <a href="XXNameSearchUrlXX"><strong>Name Search Form</strong></a> which only works if you have the exact spelling of the full name.
+    </li>
+    <li>
+        <a href="XXBpSearchUrlXX"><strong>The Blazon Pattern Search Form</strong></a> finds armory whose blazon contains particular words or text patterns. This tool can be useful, but should not be used for conflict checking, for which the Ordinary and the Armory Description Search Form are better suited. 
+    </li>
+    <li>
+        <a href="XXDateSearchUrlXX"><strong>The Date/Kingdom Search Form</strong></a> allows you to search for registrations during a particular time-period or via a particular kingdom.
+    </li>
+    <li>
+        <a href="XXComplexSearchUrlXX"><strong>The Complex Search Form</strong></a> allows you to do sophisticated searches on the database by combining the results of multiple queries.  This form is tricky to use, but when configured properly can facilitate research and speed up armory conflict-checking.
+    </li>
+</ul>
 
 <h3>Related Web Pages:</h3>
 


### PR DESCRIPTION
I’ve drafted a proposed revision to the home page of oanda.sca.org which highlights the name pattern search form rather than the exact-match version.

I’m sure there’s room for further improvement, but hopefully we can make some small changes to start and then increment from there.