### PR TITLE
Allow Configurable Site Headers

### DIFF
--- a/Morsulus-Search/assemble_here_docs.pl
+++ b/Morsulus-Search/assemble_here_docs.pl
@@ -140,6 +140,8 @@ $IndexPage{'%s'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter %s</title>
 <base href="XXIndexDirUrlXX/%s.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter %s</h2>
 <p>
 <a href="XXIndexDirUrlXX/A.html">A</a>

--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -14625,6 +14625,7 @@ $config_version = '2022-12-16 (1:127+)';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} = '';
 
+undef $config{'XXTrailerXX'} if ( $config{'XXTrailerXX'} =~ /2016/ );
 $config{'XXTrailerXX'} ||= "<hr><address>config.web version XXVersionXX ";
 $config{'XXTrailer2XX'} ||= '';
 $config{'XXCloseHtmlXX'} ||= '</address></body></html>';

--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -255,12 +255,18 @@ sub read_config_file {
     return unless -r $conf_file;
     print "\nReading previous configuration from $conf_file ...";
     open my $CONF, '<', $conf_file or die "Can't open config file $conf_file: $?";
+    my $last_tag;
     while (<$CONF>)
     {
         next if /^#/;
         chomp;
-        my ($tag, $value) = split(/\|/);
-        $config{$tag} = $value;
+        my ($tag, $value) = split(/\|/, $_, 2);
+        if ( ! length $tag ) {
+            $config{$last_tag} .= "\n" . $value;
+        } else {
+            $config{$tag} = $value;
+            $last_tag = $tag;
+        }
     }
     print " done.\n";
     return %config;
@@ -277,6 +283,7 @@ sub save_config {
     {
         next if $tag eq 'CONF_FILE';
         my $value = $config{$tag};
+        $value =~ s/\n/\n|/g;
         print $CONF "$tag|$value\n";
     }
     print " done.\n";
@@ -483,6 +490,7 @@ $SearchMenu = <<'XXEOFXX';
 <head><title>Search Forms for the SCA Armorial</title>
 <base href="XXSearchMenuUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
     <h2>Welcome to the Ordinary &amp; Armorial of the SCA</h2>
     <p>
@@ -534,6 +542,7 @@ $NameHintsPage = <<'XXEOFXX';
 <head><title>Name Search Hints</title>
 <base href="XXNameHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Name Search Hints</h2>
 
@@ -588,6 +597,7 @@ $DateHintsPage = <<'XXEOFXX';
 <head><title>Date/Kingdom Search Hints</title>
 <base href="XXDateHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Date/Kingdom Search Hints</h2>
 
@@ -660,6 +670,7 @@ $DescHintsPage = <<'XXEOFXX';
 <head><title>Armory Description Search Hints</title>
 <base href="XXDescHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Armory Description Search Hints</h2>
 <p>
@@ -749,6 +760,7 @@ $NpHintsPage = <<'XXEOFXX';
 <head><title>Name Pattern Search Hints</title>
 <base href="XXNpHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Name Pattern Search Hints</h2>
 <p>
@@ -893,6 +905,7 @@ $BpHintsPage = <<'XXEOFXX';
 <head><title>Blazon Pattern Search Hints</title>
 <base href="XXBpHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Blazon Pattern Search Hints</h2>
 <p>
@@ -1017,6 +1030,9 @@ $ComplexHintsPage = <<'XXEOFXX';
 <head><title>Complex Search Hints</title>
 <base href="XXComplexHintsPageUrlXX">XXHeadXX
 </head>
+<body>
+XXSiteHeadXX
+
 <h2>Complex Search Hints</h2>
 <p>
 Here are some hints for using the 
@@ -1130,6 +1146,7 @@ $OverviewPage = <<'XXEOFXX';
 <head><title>About SCA Heraldry</title>
 <base href="XXOverviewPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>About SCA Heraldry</h2>
 
@@ -1230,6 +1247,7 @@ $LimitPage = <<'XXEOFXX';
 <head><title>Search Limits</title>
 <base href="XXLimitPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Search Limits</h2>
 
@@ -1275,6 +1293,7 @@ $DownloadPage = <<'XXEOFXX';
 <head><title>SCA Armorial Database</title>
 <base href="XXDownloadPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Obtaining the SCA Armorial Database</h2>
 
@@ -1322,7 +1341,9 @@ $DbFormatPage = <<'XXEOFXX';
 <html>
 <head><title>Format of the SCA Armorial Database</title>
 <base href="XXDbFormatPageUrlXX">XXHeadXX
-</head><body><h2>
+</head><body>
+XXSiteHeadXX
+<h2>
                  Format of the SCA Armorial Database
 </h2><h3>
 				by
@@ -1806,7 +1827,9 @@ $DbSymbolsPage = <<'XXEOFXX';
 <head><title>Da'ud Encodings</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <base href="XXDbSymbolsPageUrlXX">XXHeadXX
-</head><body><h2>
+</head><body>
+XXSiteHeadXX
+<h2>
               Non-ASCII Symbols in the SCA Armorial Database
 </h2><h3>
 				by
@@ -2559,6 +2582,7 @@ $IndexPage = <<'XXEOFXX';
 <head><title>Online SCA Ordinary - Master Index</title>
 <base href="XXIndexDirUrlXX/index.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Online SCA Ordinary - Master Index</h2>
 <p>
@@ -2614,6 +2638,8 @@ $IndexPage{'A'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter A</title>
 <base href="XXIndexDirUrlXX/A.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter A</h2>
 
 <ul>
@@ -3022,6 +3048,8 @@ $IndexPage{'B'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter B</title>
 <base href="XXIndexDirUrlXX/B.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter B</h2>
 
 <ul>
@@ -4018,6 +4046,8 @@ $IndexPage{'C'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter C</title>
 <base href="XXIndexDirUrlXX/C.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter C</h2>
 
 <ul>
@@ -4825,6 +4855,8 @@ $IndexPage{'D'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter D</title>
 <base href="XXIndexDirUrlXX/D.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter D</h2>
 
 <ul>
@@ -5017,6 +5049,8 @@ $IndexPage{'E'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter E</title>
 <base href="XXIndexDirUrlXX/E.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter E</h2>
 
 <ul>
@@ -5154,6 +5188,8 @@ $IndexPage{'F'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter F</title>
 <base href="XXIndexDirUrlXX/F.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter F</h2>
 
 <ul>
@@ -6471,6 +6507,8 @@ $IndexPage{'G'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter G</title>
 <base href="XXIndexDirUrlXX/G.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter G</h2>
 
 <ul>
@@ -6689,6 +6727,8 @@ $IndexPage{'H'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter H</title>
 <base href="XXIndexDirUrlXX/H.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter H</h2>
 
 <ul>
@@ -7141,6 +7181,8 @@ $IndexPage{'I'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter I</title>
 <base href="XXIndexDirUrlXX/I.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter I</h2>
 
 <ul>
@@ -7217,6 +7259,8 @@ $IndexPage{'J'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter J</title>
 <base href="XXIndexDirUrlXX/J.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter J</h2>
 
 <ul>
@@ -7277,6 +7321,8 @@ $IndexPage{'K'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter K</title>
 <base href="XXIndexDirUrlXX/K.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter K</h2>
 
 <ul>
@@ -7369,6 +7415,8 @@ $IndexPage{'L'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter L</title>
 <base href="XXIndexDirUrlXX/L.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter L</h2>
 
 <ul>
@@ -7566,6 +7614,8 @@ $IndexPage{'M'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter M</title>
 <base href="XXIndexDirUrlXX/M.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter M</h2>
 
 <ul>
@@ -8167,6 +8217,8 @@ $IndexPage{'N'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter N</title>
 <base href="XXIndexDirUrlXX/N.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter N</h2>
 
 <ul>
@@ -8251,6 +8303,8 @@ $IndexPage{'O'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter O</title>
 <base href="XXIndexDirUrlXX/O.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter O</h2>
 
 <ul>
@@ -8361,6 +8415,8 @@ $IndexPage{'P'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter P</title>
 <base href="XXIndexDirUrlXX/P.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter P</h2>
 
 <ul>
@@ -8886,6 +8942,8 @@ $IndexPage{'Q'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter Q</title>
 <base href="XXIndexDirUrlXX/Q.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter Q</h2>
 
 <ul>
@@ -8938,6 +8996,8 @@ $IndexPage{'R'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter R</title>
 <base href="XXIndexDirUrlXX/R.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter R</h2>
 
 <ul>
@@ -9216,6 +9276,8 @@ $IndexPage{'S'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter S</title>
 <base href="XXIndexDirUrlXX/S.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter S</h2>
 
 <ul>
@@ -9871,6 +9933,8 @@ $IndexPage{'T'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter T</title>
 <base href="XXIndexDirUrlXX/T.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter T</h2>
 
 <ul>
@@ -10276,6 +10340,8 @@ $IndexPage{'U'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter U</title>
 <base href="XXIndexDirUrlXX/U.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter U</h2>
 
 <ul>
@@ -10320,6 +10386,8 @@ $IndexPage{'V'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter V</title>
 <base href="XXIndexDirUrlXX/V.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter V</h2>
 
 <ul>
@@ -10383,6 +10451,8 @@ $IndexPage{'W'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter W</title>
 <base href="XXIndexDirUrlXX/W.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter W</h2>
 
 <ul>
@@ -10620,6 +10690,8 @@ $IndexPage{'X'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter X</title>
 <base href="XXIndexDirUrlXX/X.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter X</h2>
 
 <ul>
@@ -10645,6 +10717,8 @@ $IndexPage{'Y'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter Y</title>
 <base href="XXIndexDirUrlXX/Y.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter Y</h2>
 
 <ul>
@@ -10684,6 +10758,8 @@ $IndexPage{'Z'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter Z</title>
 <base href="XXIndexDirUrlXX/Z.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter Z</h2>
 
 <ul>
@@ -12154,6 +12230,7 @@ print '<html><head><title>', $form_title, '</title></head>';
 
 # Print first part of HTML body.
 print '<body>';
+print q{XXSiteHeadXX};
 
 $valid = 0;
 
@@ -13343,10 +13420,13 @@ sub print_header {
   print "Content-Type:  text/html\n";
 
   # Print HTML header.
-  print '<html><head><title>', $form_title, '</title></head>';
+  print '<html><head><title>', $form_title, '</title>';
+  print q{XXHeadXX};
+  print '</head>';
 
   # Print first part of HTML body.
   print '<body>';
+  print q{XXSiteHeadXX};
   print '<form action="', $cgi_url, '",type="POST",enctype="', $enctype, '">';
   print '<h2>', $form_title, '</h2>';
 }
@@ -14623,7 +14703,8 @@ $config{'XXPrimerUrlXX'} = 'http://heraldry.sca.org/armory/newprimer/';
 $config{'XXLoARUrlXX'} = 'http://heraldry.sca.org/loar';
 $config_version = '2022-12-16 (1:127+)';
 $config{'XXVersionXX'} = $config_version;
-$config{'XXHeadXX'} = '';
+$config{'XXHeadXX'} ||= '';
+$config{'XXSiteHeadXX'} ||= '';
 
 undef $config{'XXTrailerXX'} if ( $config{'XXTrailerXX'} =~ /2016/ );
 $config{'XXTrailerXX'} ||= "<hr><address>config.web version XXVersionXX ";

--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -14616,9 +14616,9 @@ $config_version = '2022-12-16 (1:127+)';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} = '';
 
-$config{'XXTrailerXX'} = "<hr><address>config.web version $config_version ";
-$config{'XXTrailer2XX'} = '';
-$config{'XXCloseHtmlXX'} = '</address></body></html>';
+$config{'XXTrailerXX'} ||= "<hr><address>config.web version $config_version ";
+$config{'XXTrailer2XX'} ||= '';
+$config{'XXCloseHtmlXX'} ||= '</address></body></html>';
 
 #============================#
 # Set webserver parameters.  #

--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -291,9 +291,18 @@ sub configure {
 
   print "\nConfiguring $what.\n";
 
-  while (($tag, $value) = each %config) {
-    s/$tag/$value/g;
+  my $rerun = 1;
+  while ( $rerun ) {
+      $rerun = 0;
+      while (($tag, $value) = each %config) {
+        if ( s/$tag/$value/g ) {
+            if ( $value =~ /XX\w+XX/ ) {
+                $rerun ++;
+            }
+        }
+      }
   }
+
   return $_;
 }
 
@@ -14616,7 +14625,7 @@ $config_version = '2022-12-16 (1:127+)';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} = '';
 
-$config{'XXTrailerXX'} ||= "<hr><address>config.web version $config_version ";
+$config{'XXTrailerXX'} ||= "<hr><address>config.web version XXVersionXX ";
 $config{'XXTrailer2XX'} ||= '';
 $config{'XXCloseHtmlXX'} ||= '</address></body></html>';
 

--- a/Morsulus-Search/scripts/commonclient.pl
+++ b/Morsulus-Search/scripts/commonclient.pl
@@ -1016,10 +1016,13 @@ sub print_header {
   print "Content-Type:  text/html\n";
 
   # Print HTML header.
-  print '<html><head><title>', $form_title, '</title></head>';
+  print '<html><head><title>', $form_title, '</title>';
+  print q{XXHeadXX};
+  print '</head>';
 
   # Print first part of HTML body.
   print '<body>';
+  print q{XXSiteHeadXX};
   print '<form action="', $cgi_url, '",type="POST",enctype="', $enctype, '">';
   print '<h2>', $form_title, '</h2>';
 }

--- a/Morsulus-Search/scripts/commonconfig.pl
+++ b/Morsulus-Search/scripts/commonconfig.pl
@@ -82,12 +82,18 @@ sub read_config_file {
     return unless -r $conf_file;
     print "\nReading previous configuration from $conf_file ...";
     open my $CONF, '<', $conf_file or die "Can't open config file $conf_file: $?";
+    my $last_tag;
     while (<$CONF>)
     {
         next if /^#/;
         chomp;
-        my ($tag, $value) = split(/\|/);
-        $config{$tag} = $value;
+        my ($tag, $value) = split(/\|/, $_, 2);
+        if ( ! length $tag ) {
+            $config{$last_tag} .= "\n" . $value;
+        } else {
+            $config{$tag} = $value;
+            $last_tag = $tag;
+        }
     }
     print " done.\n";
     return %config;
@@ -104,6 +110,7 @@ sub save_config {
     {
         next if $tag eq 'CONF_FILE';
         my $value = $config{$tag};
+        $value =~ s/\n/\n|/g;
         print $CONF "$tag|$value\n";
     }
     print " done.\n";

--- a/Morsulus-Search/scripts/commonconfig.pl
+++ b/Morsulus-Search/scripts/commonconfig.pl
@@ -125,9 +125,18 @@ sub configure {
 
   print "\nConfiguring $what.\n";
 
-  while (($tag, $value) = each %config) {
-    s/$tag/$value/g;
+  my $rerun = 1;
+  while ( $rerun ) {
+      $rerun = 0;
+      while (($tag, $value) = each %config) {
+        if ( s/$tag/$value/g ) {
+            if ( $value =~ /XX\w+XX/ ) {
+                $rerun ++;
+            }
+        }
+      }
   }
+
   return $_;
 }
 

--- a/Morsulus-Search/scripts/config.web.tail
+++ b/Morsulus-Search/scripts/config.web.tail
@@ -43,7 +43,7 @@ $config_version = 'XXConfigVersionFromAssemblerXX';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} ||= '';
 
-$config{'XXTrailerXX'} ||= "<hr><address>config.web version $config_version ";
+$config{'XXTrailerXX'} ||= "<hr><address>config.web version XXVersionXX ";
 $config{'XXTrailer2XX'} ||= '';
 $config{'XXCloseHtmlXX'} ||= '</address></body></html>';
 

--- a/Morsulus-Search/scripts/config.web.tail
+++ b/Morsulus-Search/scripts/config.web.tail
@@ -41,7 +41,7 @@ $config{'XXPrimerUrlXX'} = 'http://heraldry.sca.org/armory/newprimer/';
 $config{'XXLoARUrlXX'} = 'http://heraldry.sca.org/loar';
 $config_version = 'XXConfigVersionFromAssemblerXX';
 $config{'XXVersionXX'} = $config_version;
-$config{'XXHeadXX'} = '';
+$config{'XXHeadXX'} ||= '';
 
 $config{'XXTrailerXX'} = "<hr><address>config.web version $config_version ";
 $config{'XXTrailer2XX'} = '';

--- a/Morsulus-Search/scripts/config.web.tail
+++ b/Morsulus-Search/scripts/config.web.tail
@@ -43,6 +43,7 @@ $config_version = 'XXConfigVersionFromAssemblerXX';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} ||= '';
 
+undef $config{'XXTrailerXX'} if ( $config{'XXTrailerXX'} =~ /2016/ );
 $config{'XXTrailerXX'} ||= "<hr><address>config.web version XXVersionXX ";
 $config{'XXTrailer2XX'} ||= '';
 $config{'XXCloseHtmlXX'} ||= '</address></body></html>';

--- a/Morsulus-Search/scripts/config.web.tail
+++ b/Morsulus-Search/scripts/config.web.tail
@@ -42,6 +42,7 @@ $config{'XXLoARUrlXX'} = 'http://heraldry.sca.org/loar';
 $config_version = 'XXConfigVersionFromAssemblerXX';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} ||= '';
+$config{'XXSiteHeadXX'} ||= '';
 
 undef $config{'XXTrailerXX'} if ( $config{'XXTrailerXX'} =~ /2016/ );
 $config{'XXTrailerXX'} ||= "<hr><address>config.web version XXVersionXX ";

--- a/Morsulus-Search/scripts/config.web.tail
+++ b/Morsulus-Search/scripts/config.web.tail
@@ -43,9 +43,9 @@ $config_version = 'XXConfigVersionFromAssemblerXX';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} ||= '';
 
-$config{'XXTrailerXX'} = "<hr><address>config.web version $config_version ";
-$config{'XXTrailer2XX'} = '';
-$config{'XXCloseHtmlXX'} = '</address></body></html>';
+$config{'XXTrailerXX'} ||= "<hr><address>config.web version $config_version ";
+$config{'XXTrailer2XX'} ||= '';
+$config{'XXCloseHtmlXX'} ||= '</address></body></html>';
 
 #============================#
 # Set webserver parameters.  #

--- a/Morsulus-Search/scripts/correction.cgi
+++ b/Morsulus-Search/scripts/correction.cgi
@@ -67,6 +67,7 @@ print '<html><head><title>', $form_title, '</title></head>';
 
 # Print first part of HTML body.
 print '<body>';
+print q{XXSiteHeadXX};
 
 $valid = 0;
 

--- a/Morsulus-Search/scripts/data_format.html
+++ b/Morsulus-Search/scripts/data_format.html
@@ -1,7 +1,9 @@
 <html>
 <head><title>Format of the SCA Armorial Database</title>
 <base href="XXDbFormatPageUrlXX">XXHeadXX
-</head><body><h2>
+</head><body>
+XXSiteHeadXX
+<h2>
                  Format of the SCA Armorial Database
 </h2><h3>
 				by

--- a/Morsulus-Search/scripts/data_obtain.html
+++ b/Morsulus-Search/scripts/data_obtain.html
@@ -2,6 +2,7 @@
 <head><title>SCA Armorial Database</title>
 <base href="XXDownloadPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Obtaining the SCA Armorial Database</h2>
 

--- a/Morsulus-Search/scripts/data_symbols.html
+++ b/Morsulus-Search/scripts/data_symbols.html
@@ -2,7 +2,9 @@
 <head><title>Da'ud Encodings</title>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <base href="XXDbSymbolsPageUrlXX">XXHeadXX
-</head><body><h2>
+</head><body>
+XXSiteHeadXX
+<h2>
               Non-ASCII Symbols in the SCA Armorial Database
 </h2><h3>
 				by

--- a/Morsulus-Search/scripts/heraldry_overview.html
+++ b/Morsulus-Search/scripts/heraldry_overview.html
@@ -2,6 +2,7 @@
 <head><title>About SCA Heraldry</title>
 <base href="XXOverviewPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>About SCA Heraldry</h2>
 

--- a/Morsulus-Search/scripts/hints_bp.html
+++ b/Morsulus-Search/scripts/hints_bp.html
@@ -2,6 +2,7 @@
 <head><title>Blazon Pattern Search Hints</title>
 <base href="XXBpHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Blazon Pattern Search Hints</h2>
 <p>

--- a/Morsulus-Search/scripts/hints_complex.html
+++ b/Morsulus-Search/scripts/hints_complex.html
@@ -2,6 +2,9 @@
 <head><title>Complex Search Hints</title>
 <base href="XXComplexHintsPageUrlXX">XXHeadXX
 </head>
+<body>
+XXSiteHeadXX
+
 <h2>Complex Search Hints</h2>
 <p>
 Here are some hints for using the 

--- a/Morsulus-Search/scripts/hints_date.html
+++ b/Morsulus-Search/scripts/hints_date.html
@@ -2,6 +2,7 @@
 <head><title>Date/Kingdom Search Hints</title>
 <base href="XXDateHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Date/Kingdom Search Hints</h2>
 

--- a/Morsulus-Search/scripts/hints_desc.html
+++ b/Morsulus-Search/scripts/hints_desc.html
@@ -2,6 +2,7 @@
 <head><title>Armory Description Search Hints</title>
 <base href="XXDescHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Armory Description Search Hints</h2>
 <p>

--- a/Morsulus-Search/scripts/hints_name.html
+++ b/Morsulus-Search/scripts/hints_name.html
@@ -2,6 +2,7 @@
 <head><title>Name Search Hints</title>
 <base href="XXNameHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Name Search Hints</h2>
 

--- a/Morsulus-Search/scripts/hints_np.html
+++ b/Morsulus-Search/scripts/hints_np.html
@@ -2,6 +2,7 @@
 <head><title>Name Pattern Search Hints</title>
 <base href="XXNpHintsPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Name Pattern Search Hints</h2>
 <p>

--- a/Morsulus-Search/scripts/index.html
+++ b/Morsulus-Search/scripts/index.html
@@ -2,6 +2,7 @@
 <head><title>Search Forms for the SCA Armorial</title>
 <base href="XXSearchMenuUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
     <h2>Welcome to the Ordinary &amp; Armorial of the SCA</h2>
     <p>

--- a/Morsulus-Search/scripts/ord_index.html
+++ b/Morsulus-Search/scripts/ord_index.html
@@ -2,6 +2,7 @@
 <head><title>Online SCA Ordinary - Master Index</title>
 <base href="XXIndexDirUrlXX/index.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Online SCA Ordinary - Master Index</h2>
 <p>

--- a/Morsulus-Search/scripts/ordinary/A.html
+++ b/Morsulus-Search/scripts/ordinary/A.html
@@ -7,6 +7,8 @@ $IndexPage{'A'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter A</title>
 <base href="XXIndexDirUrlXX/A.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter A</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/B.html
+++ b/Morsulus-Search/scripts/ordinary/B.html
@@ -7,6 +7,8 @@ $IndexPage{'B'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter B</title>
 <base href="XXIndexDirUrlXX/B.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter B</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/C.html
+++ b/Morsulus-Search/scripts/ordinary/C.html
@@ -7,6 +7,8 @@ $IndexPage{'C'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter C</title>
 <base href="XXIndexDirUrlXX/C.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter C</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/D.html
+++ b/Morsulus-Search/scripts/ordinary/D.html
@@ -7,6 +7,8 @@ $IndexPage{'D'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter D</title>
 <base href="XXIndexDirUrlXX/D.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter D</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/E.html
+++ b/Morsulus-Search/scripts/ordinary/E.html
@@ -7,6 +7,8 @@ $IndexPage{'E'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter E</title>
 <base href="XXIndexDirUrlXX/E.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter E</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/F.html
+++ b/Morsulus-Search/scripts/ordinary/F.html
@@ -7,6 +7,8 @@ $IndexPage{'F'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter F</title>
 <base href="XXIndexDirUrlXX/F.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter F</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/G.html
+++ b/Morsulus-Search/scripts/ordinary/G.html
@@ -7,6 +7,8 @@ $IndexPage{'G'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter G</title>
 <base href="XXIndexDirUrlXX/G.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter G</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/H.html
+++ b/Morsulus-Search/scripts/ordinary/H.html
@@ -7,6 +7,8 @@ $IndexPage{'H'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter H</title>
 <base href="XXIndexDirUrlXX/H.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter H</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/I.html
+++ b/Morsulus-Search/scripts/ordinary/I.html
@@ -7,6 +7,8 @@ $IndexPage{'I'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter I</title>
 <base href="XXIndexDirUrlXX/I.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter I</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/J.html
+++ b/Morsulus-Search/scripts/ordinary/J.html
@@ -7,6 +7,8 @@ $IndexPage{'J'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter J</title>
 <base href="XXIndexDirUrlXX/J.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter J</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/K.html
+++ b/Morsulus-Search/scripts/ordinary/K.html
@@ -7,6 +7,8 @@ $IndexPage{'K'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter K</title>
 <base href="XXIndexDirUrlXX/K.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter K</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/L.html
+++ b/Morsulus-Search/scripts/ordinary/L.html
@@ -7,6 +7,8 @@ $IndexPage{'L'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter L</title>
 <base href="XXIndexDirUrlXX/L.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter L</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/M.html
+++ b/Morsulus-Search/scripts/ordinary/M.html
@@ -7,6 +7,8 @@ $IndexPage{'M'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter M</title>
 <base href="XXIndexDirUrlXX/M.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter M</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/N.html
+++ b/Morsulus-Search/scripts/ordinary/N.html
@@ -7,6 +7,8 @@ $IndexPage{'N'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter N</title>
 <base href="XXIndexDirUrlXX/N.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter N</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/O.html
+++ b/Morsulus-Search/scripts/ordinary/O.html
@@ -7,6 +7,8 @@ $IndexPage{'O'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter O</title>
 <base href="XXIndexDirUrlXX/O.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter O</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/P.html
+++ b/Morsulus-Search/scripts/ordinary/P.html
@@ -7,6 +7,8 @@ $IndexPage{'P'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter P</title>
 <base href="XXIndexDirUrlXX/P.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter P</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/Q.html
+++ b/Morsulus-Search/scripts/ordinary/Q.html
@@ -7,6 +7,8 @@ $IndexPage{'Q'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter Q</title>
 <base href="XXIndexDirUrlXX/Q.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter Q</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/R.html
+++ b/Morsulus-Search/scripts/ordinary/R.html
@@ -7,6 +7,8 @@ $IndexPage{'R'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter R</title>
 <base href="XXIndexDirUrlXX/R.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter R</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/S.html
+++ b/Morsulus-Search/scripts/ordinary/S.html
@@ -7,6 +7,8 @@ $IndexPage{'S'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter S</title>
 <base href="XXIndexDirUrlXX/S.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter S</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/T.html
+++ b/Morsulus-Search/scripts/ordinary/T.html
@@ -7,6 +7,8 @@ $IndexPage{'T'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter T</title>
 <base href="XXIndexDirUrlXX/T.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter T</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/U.html
+++ b/Morsulus-Search/scripts/ordinary/U.html
@@ -7,6 +7,8 @@ $IndexPage{'U'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter U</title>
 <base href="XXIndexDirUrlXX/U.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter U</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/V.html
+++ b/Morsulus-Search/scripts/ordinary/V.html
@@ -7,6 +7,8 @@ $IndexPage{'V'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter V</title>
 <base href="XXIndexDirUrlXX/V.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter V</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/W.html
+++ b/Morsulus-Search/scripts/ordinary/W.html
@@ -7,6 +7,8 @@ $IndexPage{'W'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter W</title>
 <base href="XXIndexDirUrlXX/W.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter W</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/X.html
+++ b/Morsulus-Search/scripts/ordinary/X.html
@@ -7,6 +7,8 @@ $IndexPage{'X'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter X</title>
 <base href="XXIndexDirUrlXX/X.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter X</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/Y.html
+++ b/Morsulus-Search/scripts/ordinary/Y.html
@@ -7,6 +7,8 @@ $IndexPage{'Y'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter Y</title>
 <base href="XXIndexDirUrlXX/Y.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter Y</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/ordinary/Z.html
+++ b/Morsulus-Search/scripts/ordinary/Z.html
@@ -7,6 +7,8 @@ $IndexPage{'Z'} = <<'XXEOFXX';
 <head><title>Index of the SCA Ordinary - The Letter Z</title>
 <base href="XXIndexDirUrlXX/Z.html">XXHeadXX
 </head><body>
+XXSiteHeadXX
+
 <h2>Index of the SCA Ordinary - The Letter Z</h2>
 
 <ul>

--- a/Morsulus-Search/scripts/search_limits.html
+++ b/Morsulus-Search/scripts/search_limits.html
@@ -2,6 +2,7 @@
 <head><title>Search Limits</title>
 <base href="XXLimitPageUrlXX">XXHeadXX
 </head><body>
+XXSiteHeadXX
 
 <h2>Search Limits</h2>
 


### PR DESCRIPTION
This branch makes it possible for sites hosting the O&A search to customize the appearance of their pages using the web configuration file.

By default, no changes are made to the user-facing pages, but sites could optionally add a common bit of branding or navigation code to the top of every page by appending lines to .configweb.

Key changes:

- Saved configuration files can contain multiline strings. When writing out config files such as .configweb, if the values contain newline characters, subsequent lines are marked with leading pipe characters, then reassembled when reading the files back in.

- An XXSiteHeadXX configuration parameter is inserted at the very top of every page, immediately after the opening body tag.

- Configuration parameters that reference other configuration parameters are expanded properly. This allows us to use values like XXSearchMenuUrlXX inside of other values like XXSiteHeadXX.

With these changes in place, you could add a site-wide heading on every page of the O&A by appending the following lines to your copy of .configweb:

```
XXSiteHeadXX|<h1>
|  <a href="XXSearchMenuUrlXX">Ordinary and Armorial</a>
|</h1>
```

- The lines that begin with `|` characters represent continuation lines that are appended to XXSiteHeadXX.

- The XXSearchMenuUrlXX value inside XXSiteHeadXX is expanded to the URL of the main page of search tools.

- This new heading will be included at the top of every script and HTML page in your site.

