### PR TITLE
Allow negative weights for complex search

### DIFF
--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -11671,9 +11671,9 @@ $invalid = 0;
 $valid = 0;
 for $i (1 .. $criteria) {
     next if $p[$i] eq '';
-  if ($weight[$i] !~ /^[+&]?\d+$/) {
+  if ($weight[$i] !~ /^[+&-]?\d+$/) {
     if ($method[$i] ne '') {
-      print "<h4>You specified an invalid weight ($weight[$i]) for criterion #$i; a weight must be a positive number.</h4>";
+      print "<h4>You specified an invalid weight ($weight[$i]) for criterion #$i; a weight must be an integer.</h4>";
       $invalid++;
     }
   } else {
@@ -13423,6 +13423,7 @@ $log_file_name = '';
 
 # default limit on result-list size
 $limit = 800;
+$minimum_score = 1;
 
 # max number of waiting connections 
 $listen_queue_length = 5;
@@ -13505,7 +13506,7 @@ while (1) {
       if (/^c$/) {
         $show_copyright = 1;
 
-      } elsif (/^d(\d?) ([+&]?)(\d+) (.+)$/) {
+      } elsif (/^d(\d?) ([+&]?)([-]?\d+) (.+)$/) {
         # compatible armory description search w/tolerance
         local ($tol, $op, $weight, @descs, $desc);
 
@@ -13520,7 +13521,7 @@ while (1) {
         }
         &operation ($op, $weight);
 
-      } elsif (/^e([1-5b])(i?) ([+&]?)(\d+) (.+)$/) {
+      } elsif (/^e([1-5b])(i?) ([+&]?)([-]?\d+) (.+)$/) {
         # pattern search on field or blazons, w/flags
         local ($ind, $flags, $op, $weight, $pat, $cond, $pos);
 
@@ -13561,7 +13562,7 @@ while (1) {
           }@, $weight, $cond);
         }
 
-      } elsif (/^en(i?) ([+&]?)(\d+) (.+)$/) {
+      } elsif (/^en(i?) ([+&]?)([-]?\d+) (.+)$/) {
         # pattern search on cooked names, w/flags
         local ($flags, $op, $weight, $pat, @pos);
 
@@ -13587,7 +13588,11 @@ while (1) {
         # change the output limit
         $limit = $1 if ($limit > 0);
 
-      } elsif (/^n ([+&]?)(\d+) (.+)$/) {
+      } elsif (/^m (\d+)$/) {
+        # change the minimum score
+        $minimum_score = $1 if ($1 > 0);
+
+      } elsif (/^n ([+&]?)([-]?\d+) (.+)$/) {
         # exact search on cooked names
         local ($op, $weight, $pat, @pos);
         $op = $1;
@@ -13601,7 +13606,7 @@ while (1) {
         }
         &operation ($op, $weight);
 
-      } elsif (/^s ([+&]?)(\d+) ([12][09]\d\d[0-1]\d) ([12][09]\d\d[0-1]\d) ([A-Za-z]+)$/) {
+      } elsif (/^s ([+&]?)([-]?\d+) ([12][09]\d\d[0-1]\d) ([12][09]\d\d[0-1]\d) ([A-Za-z]+)$/) {
         # range search on dates
         local ($op, $weight, $d1, $d2, $kstring);
 
@@ -13693,13 +13698,13 @@ while (1) {
     @tops = ();
     while (($key, $tot) = each %total) {
       for ($i = $#tops; $i >= $[; $i--) {
-        ($itot, $ikey) = unpack ('N2', $tops[$i]);
+        ($itot, $ikey) = unpack ('lN', $tops[$i]);
         last if ($itot > $tot || ($itot == $tot && $ikey <= $key));
         $tops[$i+1] = $tops[$i];
       }
-      $tops[$i+1] = pack ('N2', $tot, $key);
+      $tops[$i+1] = pack ('lN', $tot, $key);
       while (@tops > $limit) {
-        $lost{unpack ('N', pop (@tops))}++;
+        $lost{unpack ('l', pop (@tops))}++;
       }
     }
     
@@ -13719,7 +13724,8 @@ while (1) {
       }
     }
     foreach $rec (@tops) {
-      ($total, $pos) = unpack ('N2', $rec);
+      ($total, $pos) = unpack ('lN', $rec);
+      next if ( $total < $minimum_score );
       $_ = &get_item ($pos);
       print NS $total, '|', $_;
       #&log ("> $total|$_");

--- a/Morsulus-Search/scripts/oanda_complex.cgi
+++ b/Morsulus-Search/scripts/oanda_complex.cgi
@@ -48,9 +48,9 @@ $invalid = 0;
 $valid = 0;
 for $i (1 .. $criteria) {
     next if $p[$i] eq '';
-  if ($weight[$i] !~ /^[+&]?\d+$/) {
+  if ($weight[$i] !~ /^[+&-]?\d+$/) {
     if ($method[$i] ne '') {
-      print "<h4>You specified an invalid weight ($weight[$i]) for criterion #$i; a weight must be a positive number.</h4>";
+      print "<h4>You specified an invalid weight ($weight[$i]) for criterion #$i; a weight must be an integer.</h4>";
       $invalid++;
     }
   } else {


### PR DESCRIPTION
This change enables you to enter negative integers in the weight fields the complex search. Weights are summed as usual, and items with a score of less than one are excluded from the result set.

For example, you can find armory with a red bear that is not fieldless by searching for description "BEAR:gules" with weight 1 and description "NO" with weight -1.