### PR TITLE
Documentation and download link for my.cat

### DIFF
--- a/Morsulus-Search/assemble_here_docs.pl
+++ b/Morsulus-Search/assemble_here_docs.pl
@@ -15,6 +15,7 @@ my %textblobs = (
     LimitPage => 'search_limits.html',
     DownloadPage => 'data_obtain.html',
     DbFormatPage => 'data_format.html',
+    CategoryFormatPage => 'category_format.html',
     DbSymbolsPage => 'data_symbols.html',
     IndexPage => 'ord_index.html',
     # IndexPage<letter> => 'ordinary/<letter>.html' for letter in A..Z
@@ -72,6 +73,7 @@ my @textnames = qw/
     LimitPage
     DownloadPage
     DbFormatPage
+    CategoryFormatPage
     DbSymbolsPage
     IndexPage
     IndexPageA

--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -41,6 +41,7 @@ if ($opt eq '-r') {
   'LimitPage', 'about search limits:search_limits',
   'DownloadPage', 'about obtaining the database:data_obtain',
   'DbFormatPage', 'about the database format:data_format',
+  'CategoryFormatPage', 'about the category format:category_format',
   'DbSymbolsPage', 'non-ASCII symbols:data_symbols'
 );
 
@@ -1301,21 +1302,38 @@ $DownloadPage = <<'XXEOFXX';
 <h2>Obtaining the SCA Armorial Database</h2>
 
 <p>
-The database used by the
-<a href="XXSearchMenuUrlXX">search forms</a> is the same data
-that is used to generate the printed SCA Armorial and SCA Ordinary.
-It is a flat text file roughly 6 megabytes in size.
-The <a href="XXDbFormatPageUrlXX">file format</a> is documented online.
+The data used by the <a href="XXSearchMenuUrlXX">search forms</a> is distributed as delimited text files.
+
+<h3>Database File</h3>
+<p>
+The armorial data is stored in a delimited text file known as oanda.db, which is roughly 18 MB in size.
 
 <p>
-The database is protected by copyright, but that broad
+You can download the database from <a href="XXWebDataUrlXX">XXWebDataUrlXX</a>.
+
+<p>
+The <a href="XXDbFormatPageUrlXX">file format is documented here</a>.
+
+<p>
+<a href="XXVersionUrlXX">Check the database version number</a> to determine which data file is currently in use.
+
+<h3>Category File</h3>
+<p>
+The armorial descriptions are stored using codes defined in a file known as my.cat, which is roughly 128 KB in size. 
+
+<p>
+You can download the category file via
+HTTP from <a href="XXWebCategoryUrlXX">XXWebCategoryUrlXX</a>
+
+<p>
+The <a href="XXCategoryFormatPageUrlXX">file format is documented here</a>.
+
+<h3>Copyright</h3>
+<p>
+The database is protected by copyright, but broad
 blanket permissions have been granted for verbatim
 redistribution and personal use.  See the
 <a href="XXCopyrightUrlXX">copyright notice</a> for details.
-
-<p>
-You should be able to download the database via
-HTTP from <a href="XXWebDataUrlXX">XXWebDataUrlXX</a> (not compressed).
 
 XXTrailerXX
 XXTrailer2XX
@@ -1634,6 +1652,170 @@ and notes, in that order.
 <li><a href="XXOverviewPageUrlXX">About SCA Heraldry</a>
 <li><a href="XXSearchMenuUrlXX">Search Forms for the SCA Armorial</a>
 </ul>
+XXTrailerXX
+XXTrailer2XX
+XXCloseHtmlXX
+
+XXEOFXX
+
+$CategoryFormatPage = <<'XXEOFXX';
+<html>
+<head><title>Format of the SCA Armorial Database</title>
+<base href="XXDbFormatPageUrlXX">XXHeadXX
+</head><body>
+XXSiteHeadXX
+
+<h2>Format of the Category File</h2>
+
+<p>
+The armorial descriptions in the database are stored using codes defined in a text file known as my.cat, which is roughly 128 KB in size. 
+
+<p>
+You can download the category file via
+HTTP from <a href="XXWebCategoryUrlXX">XXWebCategoryUrlXX</a>
+
+<p>
+The category file is divided into three sections, each of which uses a different format:
+<ul>
+<li> Features (around 350 lines) function as adjectives, such as <code>argent</code> or <code>maltese</code>, providing additional details about a description.</li>
+<li> Categories (around 450 lines) function as nouns, such as <code>CROSS</code> or <code>HUMAN FIGURE</code>, providing the core content of a description.</li>
+<li> Cross-references (around 2,750 lines) list additional terms which are grouped under another category, such as <code>woman - see human figure</code>.</li>
+</ul>
+
+Although the features section of the file appears first in the file, we'll discuss the other two sections first here because categories appear before features when entering search terms.
+
+<h3>
+Categories
+</h3>
+
+<p>
+Categories are the core of armory descriptions. 
+
+<p>
+Each category line contains a human-readable term, then a pipe character ("<code>|</code>"), followed by a capitalized category code.
+
+<p>
+For example, here are a selection of category lines.
+
+<pre>
+axe|AXE
+azure field|AZ
+beast, bear|BEAST-BEAR
+beast, dog|DOG
+bird, demi|BIRD9DEMI
+bird, whole|BIRD
+cross, as charge|CRAC
+cross, throughout|CROSS
+field division, per fess|PFESS
+field division, per pale|PPALE
+pole axe|POLE-AXE
+</pre>
+
+<p>
+As you can see, the category code is sometimes a predictable capitalized version of the human-readable term, and other times is more idiosyncratic.
+
+<p>
+Most categories represent types of charges, but some correspond to solid fields or field divisions, and others indicate specific arrangments of charges.
+
+<h3>
+Cross-References
+</h3>
+
+<p>
+Cross-references make it easier to find individual category terms.
+
+<p>
+Each cross-reference line contains a human-readable term, then either "<code>see</code>" or "<code>see also</code>", followed by one or more human-readable category names.
+
+<p>
+For example, here are a selection of cross-reference lines.
+
+<pre>
+axe - see also pole axe
+broadaxe - see axe
+</pre>
+
+<p>
+The <code>see also</code> lines mark places where one category is being linked to another, related category, so in the above example so we can expect to find both <code>axe</code> and <code>pole axe</code> in the category list.
+
+<p>
+The <code>see</code> lines mark places where an additional term is being linked to an existing category, so the above example is telling us that there is no <code>broadaxe</code> category and instead all broadaxes are indexed under the <code>axe</code> category.
+
+<p>
+Some cross-reference lines direct you to more than one corresponding category, separated by <code>and</code>.
+
+<pre>
+bluejay - see bird, whole and bird, demi
+swallow - see bird, whole and bird, demi
+</pre>
+
+<p>
+The above example shows that bluejays and swallows are each indexed in one of two distinct categories, either <code>bird, whole</code> or <code>bird, demi</code>.
+
+<p>
+Many of the cross references define varieties, heraldic synonyms, or related charges that are indexed together.
+
+<pre>
+alaunt - see beast, dog
+cub, wolf - see beast, dog
+fox - see beast, dog
+husky - see beast, dog
+hyena - see beast, dog
+talbot - see beast, dog
+wolf - see beast, dog
+</pre>
+
+<p>
+Each of these is either a variety of dog (husky), or an old heraldic term for a variety of dog (alaunt, talbot), or a related canine that is indexed with dogs (fox, hyena, wolf).
+
+<h3>
+Features
+</h3>
+
+<p>
+Features are used to provide additional details about armory descriptions.
+
+<p>
+Each feature line starts with a pipe character ("<code>|</code>"), then has a feature set name followed by a colon, and then the individual feature name. 
+
+<p>
+For example, the <code>cross_family</code> feature set is used to mark subtypes of crosses. Its contents are defined in a series of lines like the below:
+<pre>
+|cross_family:crosslet
+|cross_family:flory
+|cross_family:maltese
+</pre>
+
+<p>
+The feature name may optionaly be followed by one or more markers showing their relationship to other feature names.
+
+<p>
+For example, the <code>tincture</code> feature set is used to mark the coloration of fields or charges. Its contents are defined in a series of lines like the below:
+
+<pre>
+|tincture:argent&lt;light
+|tincture:ermine&lt;fur&lt;light
+|tincture:neutral=multicolor=fur
+</pre>
+
+<p>
+The first line defines a <code>tincture</code> code named <code>argent</code>, and indicates that it is a subtype of the <code>tincture</code> named <code>light</code>. The second line defines a <code>tincture</code> named <code>ermine</code> and marks it as a subtype of both <code>fur</code> and <code>light</code>. The third line defines a <code>tincture</code> named <code>neutral</code> and marks it as equivalent to both <code>multicolor</code> and <code>fur</code>.
+
+<p>
+The subtype relationship defined by the <code>&lt;</code> chracter indicates that the term on the left is a more-specific feature encompased by the term on the right. For example, a search for <code>CROSS:light</code> should also match any armory that is marked as <code>CROSS:argent</code>. However, this relationship is not symatrical; if you search for <code>CROSS:argent</code>, it should not match armory that is marked as <code>CROSS:light</code>.
+
+<p>
+The equivalence relationship defined by the <code>=</code> chracter indicates a symetrical relationship between the terms. For example, a search for <code>CROSS:neutral</code> should also match any armory that is marked as <code>CROSS:multicolor</code>, and a search for <code>CROSS:multicolor</code> should also match any armory that is marked as <code>CROSS:neutral</code>.
+
+<p>
+Individual armory descriptions may combine multiple features from different feature sets. For example, an Maltese cross throughout argent might be coded as <code>CROSS:maltese:argent</code>
+
+<p>
+Individual armory descriptions never use more than one feature from a given feature set. For example, there will never be a cross with two different cross features such as <code>CROSS:crosslet:maltese</code>. 
+
+<p>
+Some feature sets are only applicable to certain categories. For example, the features in the <code>bird_posture</code> feature set are only ever used with the <code>BIRD</code> or <code>BIRD9DEMI</code> categories.
+
 XXTrailerXX
 XXTrailer2XX
 XXCloseHtmlXX
@@ -13503,6 +13685,10 @@ $PageUrl = &get_html_url ('XXPageUrlXX', 'O&A web pages', $PagePath);
 $WebDataPath = &get_filepath ('XXWebDataPathXX', 'database file',
    'oanda.db', $DocumentRoot);
 $WebDataUrl = &get_html_url ('XXWebDataUrlXX', 'database file', $WebDataPath);
+ 
+$WebCategoryPath = &get_filepath ('XXWebCategoryPathXX', 'category file',
+   'my.cat', $DocumentRoot);
+$WebCategoryUrl = &get_html_url ('XXWebCategoryUrlXX', 'category file', $WebCategoryPath);
 
 foreach $tag (keys %pages) {
   &set_page_info ($tag);
@@ -13623,6 +13809,7 @@ $ConfigDbPath = &get_filepath ('XXConfigDbPathXX',
 &page_install ($LimitPage, 'LimitPage');
 &page_install ($DownloadPage, 'DownloadPage');
 &page_install ($DbFormatPage, 'DbFormatPage');
+&page_install ($CategoryFormatPage, 'CategoryFormatPage');
 &page_install ($DbSymbolsPage, 'DbSymbolsPage');
 
 &install ($IndexPage, "$IndexDirPath/index.html", 0444,

--- a/Morsulus-Search/scripts/category_format.html
+++ b/Morsulus-Search/scripts/category_format.html
@@ -1,0 +1,160 @@
+<html>
+<head><title>Format of the SCA Armorial Database</title>
+<base href="XXDbFormatPageUrlXX">XXHeadXX
+</head><body>
+XXSiteHeadXX
+
+<h2>Format of the Category File</h2>
+
+<p>
+The armorial descriptions in the database are stored using codes defined in a text file known as my.cat, which is roughly 128 KB in size. 
+
+<p>
+You can download the category file via
+HTTP from <a href="XXWebCategoryUrlXX">XXWebCategoryUrlXX</a>
+
+<p>
+The category file is divided into three sections, each of which uses a different format:
+<ul>
+<li> Features (around 350 lines) function as adjectives, such as <code>argent</code> or <code>maltese</code>, providing additional details about a description.</li>
+<li> Categories (around 450 lines) function as nouns, such as <code>CROSS</code> or <code>HUMAN FIGURE</code>, providing the core content of a description.</li>
+<li> Cross-references (around 2,750 lines) list additional terms which are grouped under another category, such as <code>woman - see human figure</code>.</li>
+</ul>
+
+Although the features section of the file appears first in the file, we'll discuss the other two sections first here because categories appear before features when entering search terms.
+
+<h3>
+Categories
+</h3>
+
+<p>
+Categories are the core of armory descriptions. 
+
+<p>
+Each category line contains a human-readable term, then a pipe character ("<code>|</code>"), followed by a capitalized category code.
+
+<p>
+For example, here are a selection of category lines.
+
+<pre>
+axe|AXE
+azure field|AZ
+beast, bear|BEAST-BEAR
+beast, dog|DOG
+bird, demi|BIRD9DEMI
+bird, whole|BIRD
+cross, as charge|CRAC
+cross, throughout|CROSS
+field division, per fess|PFESS
+field division, per pale|PPALE
+pole axe|POLE-AXE
+</pre>
+
+<p>
+As you can see, the category code is sometimes a predictable capitalized version of the human-readable term, and other times is more idiosyncratic.
+
+<p>
+Most categories represent types of charges, but some correspond to solid fields or field divisions, and others indicate specific arrangments of charges.
+
+<h3>
+Cross-References
+</h3>
+
+<p>
+Cross-references make it easier to find individual category terms.
+
+<p>
+Each cross-reference line contains a human-readable term, then either "<code>see</code>" or "<code>see also</code>", followed by one or more human-readable category names.
+
+<p>
+For example, here are a selection of cross-reference lines.
+
+<pre>
+axe - see also pole axe
+broadaxe - see axe
+</pre>
+
+<p>
+The <code>see also</code> lines mark places where one category is being linked to another, related category, so in the above example so we can expect to find both <code>axe</code> and <code>pole axe</code> in the category list.
+
+<p>
+The <code>see</code> lines mark places where an additional term is being linked to an existing category, so the above example is telling us that there is no <code>broadaxe</code> category and instead all broadaxes are indexed under the <code>axe</code> category.
+
+<p>
+Some cross-reference lines direct you to more than one corresponding category, separated by <code>and</code>.
+
+<pre>
+bluejay - see bird, whole and bird, demi
+swallow - see bird, whole and bird, demi
+</pre>
+
+<p>
+The above example shows that bluejays and swallows are each indexed in one of two distinct categories, either <code>bird, whole</code> or <code>bird, demi</code>.
+
+<p>
+Many of the cross references define varieties, heraldic synonyms, or related charges that are indexed together.
+
+<pre>
+alaunt - see beast, dog
+cub, wolf - see beast, dog
+fox - see beast, dog
+husky - see beast, dog
+hyena - see beast, dog
+talbot - see beast, dog
+wolf - see beast, dog
+</pre>
+
+<p>
+Each of these is either a variety of dog (husky), or an old heraldic term for a variety of dog (alaunt, talbot), or a related canine that is indexed with dogs (fox, hyena, wolf).
+
+<h3>
+Features
+</h3>
+
+<p>
+Features are used to provide additional details about armory descriptions.
+
+<p>
+Each feature line starts with a pipe character ("<code>|</code>"), then has a feature set name followed by a colon, and then the individual feature name. 
+
+<p>
+For example, the <code>cross_family</code> feature set is used to mark subtypes of crosses. Its contents are defined in a series of lines like the below:
+<pre>
+|cross_family:crosslet
+|cross_family:flory
+|cross_family:maltese
+</pre>
+
+<p>
+The feature name may optionaly be followed by one or more markers showing their relationship to other feature names.
+
+<p>
+For example, the <code>tincture</code> feature set is used to mark the coloration of fields or charges. Its contents are defined in a series of lines like the below:
+
+<pre>
+|tincture:argent&lt;light
+|tincture:ermine&lt;fur&lt;light
+|tincture:neutral=multicolor=fur
+</pre>
+
+<p>
+The first line defines a <code>tincture</code> code named <code>argent</code>, and indicates that it is a subtype of the <code>tincture</code> named <code>light</code>. The second line defines a <code>tincture</code> named <code>ermine</code> and marks it as a subtype of both <code>fur</code> and <code>light</code>. The third line defines a <code>tincture</code> named <code>neutral</code> and marks it as equivalent to both <code>multicolor</code> and <code>fur</code>.
+
+<p>
+The subtype relationship defined by the <code>&lt;</code> chracter indicates that the term on the left is a more-specific feature encompased by the term on the right. For example, a search for <code>CROSS:light</code> should also match any armory that is marked as <code>CROSS:argent</code>. However, this relationship is not symatrical; if you search for <code>CROSS:argent</code>, it should not match armory that is marked as <code>CROSS:light</code>.
+
+<p>
+The equivalence relationship defined by the <code>=</code> chracter indicates a symetrical relationship between the terms. For example, a search for <code>CROSS:neutral</code> should also match any armory that is marked as <code>CROSS:multicolor</code>, and a search for <code>CROSS:multicolor</code> should also match any armory that is marked as <code>CROSS:neutral</code>.
+
+<p>
+Individual armory descriptions may combine multiple features from different feature sets. For example, an Maltese cross throughout argent might be coded as <code>CROSS:maltese:argent</code>
+
+<p>
+Individual armory descriptions never use more than one feature from a given feature set. For example, there will never be a cross with two different cross features such as <code>CROSS:crosslet:maltese</code>. 
+
+<p>
+Some feature sets are only applicable to certain categories. For example, the features in the <code>bird_posture</code> feature set are only ever used with the <code>BIRD</code> or <code>BIRD9DEMI</code> categories.
+
+XXTrailerXX
+XXTrailer2XX
+XXCloseHtmlXX

--- a/Morsulus-Search/scripts/config.web.head
+++ b/Morsulus-Search/scripts/config.web.head
@@ -41,6 +41,7 @@ if ($opt eq '-r') {
   'LimitPage', 'about search limits:search_limits',
   'DownloadPage', 'about obtaining the database:data_obtain',
   'DbFormatPage', 'about the database format:data_format',
+  'CategoryFormatPage', 'about the category format:category_format',
   'DbSymbolsPage', 'non-ASCII symbols:data_symbols'
 );
 

--- a/Morsulus-Search/scripts/config.web.tail
+++ b/Morsulus-Search/scripts/config.web.tail
@@ -170,6 +170,10 @@ $PageUrl = &get_html_url ('XXPageUrlXX', 'O&A web pages', $PagePath);
 $WebDataPath = &get_filepath ('XXWebDataPathXX', 'database file',
    'oanda.db', $DocumentRoot);
 $WebDataUrl = &get_html_url ('XXWebDataUrlXX', 'database file', $WebDataPath);
+ 
+$WebCategoryPath = &get_filepath ('XXWebCategoryPathXX', 'category file',
+   'my.cat', $DocumentRoot);
+$WebCategoryUrl = &get_html_url ('XXWebCategoryUrlXX', 'category file', $WebCategoryPath);
 
 foreach $tag (keys %pages) {
   &set_page_info ($tag);
@@ -290,6 +294,7 @@ $ConfigDbPath = &get_filepath ('XXConfigDbPathXX',
 &page_install ($LimitPage, 'LimitPage');
 &page_install ($DownloadPage, 'DownloadPage');
 &page_install ($DbFormatPage, 'DbFormatPage');
+&page_install ($CategoryFormatPage, 'CategoryFormatPage');
 &page_install ($DbSymbolsPage, 'DbSymbolsPage');
 
 &install ($IndexPage, "$IndexDirPath/index.html", 0444,

--- a/Morsulus-Search/scripts/data_obtain.html
+++ b/Morsulus-Search/scripts/data_obtain.html
@@ -6,21 +6,38 @@
 <h2>Obtaining the SCA Armorial Database</h2>
 
 <p>
-The database used by the
-<a href="XXSearchMenuUrlXX">search forms</a> is the same data
-that is used to generate the printed SCA Armorial and SCA Ordinary.
-It is a flat text file roughly 6 megabytes in size.
-The <a href="XXDbFormatPageUrlXX">file format</a> is documented online.
+The data used by the <a href="XXSearchMenuUrlXX">search forms</a> is distributed as delimited text files.
+
+<h3>Database File</h3>
+<p>
+The armorial data is stored in a delimited text file known as oanda.db, which is roughly 18 MB in size.
 
 <p>
-The database is protected by copyright, but that broad
+You can download the database from <a href="XXWebDataUrlXX">XXWebDataUrlXX</a>.
+
+<p>
+The <a href="XXDbFormatPageUrlXX">file format is documented here</a>.
+
+<p>
+<a href="XXVersionUrlXX">Check the database version number</a> to determine which data file is currently in use.
+
+<h3>Category File</h3>
+<p>
+The armorial descriptions are stored using codes defined in a file known as my.cat, which is roughly 128 KB in size. 
+
+<p>
+You can download the category file via
+HTTP from <a href="XXWebCategoryUrlXX">XXWebCategoryUrlXX</a>
+
+<p>
+The <a href="XXCategoryFormatPageUrlXX">file format is documented here</a>.
+
+<h3>Copyright</h3>
+<p>
+The database is protected by copyright, but broad
 blanket permissions have been granted for verbatim
 redistribution and personal use.  See the
 <a href="XXCopyrightUrlXX">copyright notice</a> for details.
-
-<p>
-You should be able to download the database via
-HTTP from <a href="XXWebDataUrlXX">XXWebDataUrlXX</a> (not compressed).
 
 XXTrailerXX
 XXTrailer2XX


### PR DESCRIPTION
The change updates the "Obtaining the Database" page with links to download my.cat and a new page that documents the category file format.

It also makes a few incidental changes to the "Obtaining the Database" page, which no longer mentions printed versions of the ordinary and armorial, and now accurately reflects the current size of the oanda.db file.

The documentation for my.cat provides a quick outline of the three types of lines it contains, along with some comments on how to interpret each kind of line. There's room for a lot more detail, but this is at least a start.

To enable downloads of the my.cat file, additional questions have been added to the config.web script, with sensible default values.