### PR TITLE
Support pipe-separated alternatives in fixcase

### DIFF
--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -12446,10 +12446,12 @@ sub print_trailer {
 sub fixcase # make heading UC, features lc
 {
     my $desc = shift;
-    my ($hdg, $features) = split(/:/, $desc, 2);
-    $hdg = uc($hdg);
-    $features = lc($features) if defined $features;
-    return defined $features ? "$hdg:$features" : $hdg;
+    join '|', map {
+        my ($hdg, $features) = split(/:/, $_, 2);
+        $hdg = uc($hdg);
+        $features = lc($features) if defined $features;
+        defined $features ? "$hdg:$features" : $hdg;
+    } ( split '[|]', $desc )
 }
 1;
 # end of XXCommonClientPathXX

--- a/Morsulus-Search/scripts/commonclient.pl
+++ b/Morsulus-Search/scripts/commonclient.pl
@@ -1017,10 +1017,12 @@ sub print_trailer {
 sub fixcase # make heading UC, features lc
 {
     my $desc = shift;
-    my ($hdg, $features) = split(/:/, $desc, 2);
-    $hdg = uc($hdg);
-    $features = lc($features) if defined $features;
-    return defined $features ? "$hdg:$features" : $hdg;
+    join '|', map {
+        my ($hdg, $features) = split(/:/, $_, 2);
+        $hdg = uc($hdg);
+        $features = lc($features) if defined $features;
+        defined $features ? "$hdg:$features" : $hdg;
+    } ( split '[|]', $desc )
 }
 1;
 # end of XXCommonClientPathXX


### PR DESCRIPTION
The fixcase function is nifty — it catches people who might have searched for `Rose:Primary` and converts that to the `ROSE:primary` format that the database server is expecting.

Unfortunately, it was written without consideration of the database server's support of pipe-separated alternatives, like `ROSE:primary|SWORD:primary`, and it forces everything to the right of the first colon to lower case, yielding `ROSE:primary|sword:primary`, which isn't what the database server wants.

This change teaches the fixcase function to capitalize the first time in each pipe-separated section of the search term, restoring the support for alternatives.

I'm still not positive what the best practices are for using this feature, but I bet that once we re-enable it, people will figure out ways to put it to good use.