### PR TITLE
No dollar left bracket

### DIFF
--- a/Morsulus-Search/assemble_here_docs.pl
+++ b/Morsulus-Search/assemble_here_docs.pl
@@ -122,7 +122,6 @@ $cat_file_name = 'scripts/temp.cat';
 $print_file_name = 'scripts/tprint.cat';
 
 $\ = "\n";     # print a newline after every print statment.
-$[ = 1;        # index of first element in a list
 $" = ':';     # list separator for interpolation
 
 read_cat_file ($cat_file_name);
@@ -167,7 +166,7 @@ while (<PRINT_FILE>) {
     if ($target{$t}) {
       $urlt = $t;
       $urlt =~ s/[^A-Za-z0-9]//g;
-      $this = substr ($urlt, 1, 1);
+      $this = substr ($urlt, 0, 1);
       $this =~ tr/[a-z]/[A-Z]/;
       if ($this ne $last) {
         print  $fh $tail unless ($last eq '');
@@ -193,7 +192,7 @@ while (<PRINT_FILE>) {
 
   $cat = publish ($_);
 
-  $this = substr ($_, 1, 1);
+  $this = substr ($_, 0, 1);
   $this =~ tr/[a-z]/[A-Z]/;
   if ($this ne $last) {
     print $fh $tail unless ($last eq '');
@@ -277,7 +276,7 @@ sub read_cat_file {
 sub encode {
   # Encode non-alphanumeric characters when generating a URL.
   local($out) = '';
-  local($_) = $_[1];
+  local($_) = $_[0];
     
   local(@chars) = split (//, $_);
   foreach (@chars) {
@@ -291,8 +290,8 @@ sub encode {
 }
 
 sub publish {
-  @f = split (/, /, @_[1]); 
-  grep (substr($_,1,1) =~ tr/[a-z]/[A-Z]/, @f);
+  @f = split (/, /, @_[0]);
+  grep (substr($_,0,1) =~ tr/[a-z]/[A-Z]/, @f);
   $cat = join (', ', @f);
   $cat =~ s/,/ -/g;
   $cat =~ s/~//g;
@@ -302,8 +301,8 @@ sub publish {
 }
 
 sub cref {
-  local ($name) = @_[1];
-  $letter = substr ($name, 1, 1);
+  local ($name) = @_[0];
+  $letter = substr ($name, 0, 1);
   $letter =~ tr/a-z/A-Z/;
   $name =~ s/[^A-Za-z0-9]//g;
   return sprintf ('<a href="%s.html#%s">%s</a>',

--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -12891,17 +12891,17 @@ while (1) {
             ($d1,$d2) = split (/\-/, $f2);
             $flag = 0;
             if ($d1 ne '') {
-              $k1 = substr($d1, 7);
+              $k1 = substr($d1, 6);
               if ($k1 eq '' || index($kstring, $k1) != $[-1) {
-                $d1 = substr($d1, 1, 6);
+                $d1 = substr($d1, 0, 6);
                 $d1 += 10000 if ($d1 < 196600);
                 $flag = 1 if ($d1 >= $date1 && $d1 <= $date2);
               }
             }
             if ($d2 ne '' && $flag eq 0) {
-              $k2 = substr($d2, 7);
+              $k2 = substr($d2, 6);
               if ($k2 eq '' || index($kstring, $k2) != $[-1) {
-                $d2 = substr($d2, 1, 6);
+                $d2 = substr($d2, 0, 6);
                 $d2 += 10000 if ($d2 < 196600);
                 $flag = 1 if ($d2 >= $date1 && $d2 <= $date2);
               }
@@ -12921,17 +12921,17 @@ while (1) {
             ($d1,$d2) = split (/\-/, $f2);
             $flag = 0;
             if ($d1 ne '') {
-              $k1 = substr($d1, 7);
+              $k1 = substr($d1, 6);
               if ($k1 eq '' || index($kstring, $k1) != $[-1) {
-                $d1 = substr($d1, 1, 6);
+                $d1 = substr($d1, 0, 6);
                 $d1 += 10000 if ($d1 < 196600);
                 $flag = 1 if ($d1 >= $date1 && $d1 <= $date2);
               }
             }
             if ($d2 ne '' && $flag eq 0) {
-              $k2 = substr($d2, 7);
+              $k2 = substr($d2, 6);
               if ($k2 eq '' || index($kstring, $k2) != $[-1) {
-                $d2 = substr($d2, 1, 6);
+                $d2 = substr($d2, 0, 6);
                 $d2 += 10000 if ($d2 < 196600);
                 $flag = 1 if ($d2 >= $date1 && $d2 <= $date2);
               }

--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -12706,7 +12706,6 @@ $listen_queue_length = 5;
 #   set -- "number" and "tincture" are _sets_
 
 $\ = "\n";     # print a newline after every print statment.
-$[ = 1;        # index of first element in a list
 $; = ':';      # separator for lookup arguments
 $" = '.';      # separator for octets of IP address
 $, = '';       # separator for print items
@@ -13035,7 +13034,7 @@ sub log {
   #  Note the time.
   @time = localtime time;
   $ts = sprintf ('%02u%02u%02u %02u:%02u:%02u(%u)',
-    $time[6], $time[5]+1, $time[4], $time[3], $time[2], $time[1], $$);
+    $time[5], $time[4]+1, $time[3], $time[2], $time[1], $time[0], $$);
   print LOG_FILE $ts, $msg;
 }
 
@@ -13432,7 +13431,7 @@ sub permute {
 
 # Database server function to convert Latin-1 strings to ASCII.
 sub ascii {
-  local ($_) = $_[1];
+  local ($_) = $_[0];
   tr/\300\301\302\303\304\305\307\310\311\312\313\314\315\316\317\321\322\323\324\325\326\330\331\332\333\334\335\340\341\342\343\344\345\347\350\351\352\353\354\355\356\357\361\362\363\364\365\366\370\371\372\373\374\375\377/AAAAAACEEEEIIIINOOOOOOUUUUYaaaaaaceeeeiiiinoooooouuuuyy/;
   s/\306/AE/g;
   s/\320/Dh/g;

--- a/Morsulus-Search/scripts/configdb.pl
+++ b/Morsulus-Search/scripts/configdb.pl
@@ -250,17 +250,17 @@ while (1) {
             ($d1,$d2) = split (/\-/, $f2);
             $flag = 0;
             if ($d1 ne '') {
-              $k1 = substr($d1, 7);
+              $k1 = substr($d1, 6);
               if ($k1 eq '' || index($kstring, $k1) != $[-1) {
-                $d1 = substr($d1, 1, 6);
+                $d1 = substr($d1, 0, 6);
                 $d1 += 10000 if ($d1 < 196600);
                 $flag = 1 if ($d1 >= $date1 && $d1 <= $date2);
               }
             }
             if ($d2 ne '' && $flag eq 0) {
-              $k2 = substr($d2, 7);
+              $k2 = substr($d2, 6);
               if ($k2 eq '' || index($kstring, $k2) != $[-1) {
-                $d2 = substr($d2, 1, 6);
+                $d2 = substr($d2, 0, 6);
                 $d2 += 10000 if ($d2 < 196600);
                 $flag = 1 if ($d2 >= $date1 && $d2 <= $date2);
               }
@@ -280,17 +280,17 @@ while (1) {
             ($d1,$d2) = split (/\-/, $f2);
             $flag = 0;
             if ($d1 ne '') {
-              $k1 = substr($d1, 7);
+              $k1 = substr($d1, 6);
               if ($k1 eq '' || index($kstring, $k1) != $[-1) {
-                $d1 = substr($d1, 1, 6);
+                $d1 = substr($d1, 0, 6);
                 $d1 += 10000 if ($d1 < 196600);
                 $flag = 1 if ($d1 >= $date1 && $d1 <= $date2);
               }
             }
             if ($d2 ne '' && $flag eq 0) {
-              $k2 = substr($d2, 7);
+              $k2 = substr($d2, 6);
               if ($k2 eq '' || index($kstring, $k2) != $[-1) {
-                $d2 = substr($d2, 1, 6);
+                $d2 = substr($d2, 0, 6);
                 $d2 += 10000 if ($d2 < 196600);
                 $flag = 1 if ($d2 >= $date1 && $d2 <= $date2);
               }

--- a/Morsulus-Search/scripts/configdb.pl
+++ b/Morsulus-Search/scripts/configdb.pl
@@ -65,7 +65,6 @@ $listen_queue_length = 5;
 #   set -- "number" and "tincture" are _sets_
 
 $\ = "\n";     # print a newline after every print statment.
-$[ = 1;        # index of first element in a list
 $; = ':';      # separator for lookup arguments
 $" = '.';      # separator for octets of IP address
 $, = '';       # separator for print items
@@ -394,7 +393,7 @@ sub log {
   #  Note the time.
   @time = localtime time;
   $ts = sprintf ('%02u%02u%02u %02u:%02u:%02u(%u)',
-    $time[6], $time[5]+1, $time[4], $time[3], $time[2], $time[1], $$);
+    $time[5], $time[4]+1, $time[3], $time[2], $time[1], $time[0], $$);
   print LOG_FILE $ts, $msg;
 }
 
@@ -791,7 +790,7 @@ sub permute {
 
 # Database server function to convert Latin-1 strings to ASCII.
 sub ascii {
-  local ($_) = $_[1];
+  local ($_) = $_[0];
   tr/\300\301\302\303\304\305\307\310\311\312\313\314\315\316\317\321\322\323\324\325\326\330\331\332\333\334\335\340\341\342\343\344\345\347\350\351\352\353\354\355\356\357\361\362\363\364\365\366\370\371\372\373\374\375\377/AAAAAACEEEEIIIINOOOOOOUUUUYaaaaaaceeeeiiiinoooooouuuuyy/;
   s/\306/AE/g;
   s/\320/Dh/g;


### PR DESCRIPTION
Assigning to the $[ variable is frowned upon in modern Perl coding, and fails altogether in the latest versions of the language.

These changes eliminate the `$[ = 1;` assignments in assemble_here_docs.pl and in scripts/*.cgi and tweak all of the lines of code which relied on the old behavior so that no differences in functionality are visible to end-users.