### PR TITLE
Auto-generate meaningful config.web version numbers

### DIFF
--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -14156,7 +14156,7 @@ $conf_file = '.configweb';
 
 $config{'XXPrimerUrlXX'} = 'http://heraldry.sca.org/armory/newprimer/';
 $config{'XXLoARUrlXX'} = 'http://heraldry.sca.org/loar';
-$config_version = 20160910;
+$config_version = '2020-09-07 (mathghamhain:auto-web-version:121)';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} = '';
 

--- a/Morsulus-Search/scripts/config.web.tail
+++ b/Morsulus-Search/scripts/config.web.tail
@@ -39,7 +39,7 @@ $conf_file = '.configweb';
 
 $config{'XXPrimerUrlXX'} = 'http://heraldry.sca.org/armory/newprimer/';
 $config{'XXLoARUrlXX'} = 'http://heraldry.sca.org/loar';
-$config_version = 20160910;
+$config_version = 'XXConfigVersionFromAssemblerXX';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} = '';
 


### PR DESCRIPTION
There has long been a hard-coded version number in config.web which only got updated if a diligent developer did so deliberately.

This change replaces that with a version string generated each time you run assemble_here_docs.pl. The version string includes the local date in YYYY-MM-DD format, and a parenthetical revision-control marker pulled from Git.

The revision marker will include:
* the Git repository owner's name if it is not `herveus`,
* the branch name if it is not `master`,
* the number of committed revisions in that branch, and
* a plus sign if there are un-committed changes in your repository.

As a result, when run in the main branch when everything has been checked into Git, you should generate version strings that look like `2020-09-07 (125)`, meaning that you're in herveus:master at commit 125.

For comparison, when running in my development branch with uncommitted changes, I am generating version strings that look like `2020-09-07 (mathghamhain:development:154+)`.