### PR TITLE
Proper date format in oanda_server.pl log output

### DIFF
--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -13761,8 +13761,8 @@ sub log {
 
   #  Note the time.
   @time = localtime time;
-  $ts = sprintf ('%02u%02u%02u %02u:%02u:%02u(%u)',
-    $time[5], $time[4]+1, $time[3], $time[2], $time[1], $time[0], $$);
+  $ts = sprintf ('%04u-%02u-%02u %02u:%02u:%02u (%u)',
+    $time[5] += 1900, $time[4]+1, $time[3], $time[2], $time[1], $time[0], $$);
   print LOG_FILE $ts, $msg;
 }
 

--- a/Morsulus-Search/scripts/configdb.pl
+++ b/Morsulus-Search/scripts/configdb.pl
@@ -392,8 +392,8 @@ sub log {
 
   #  Note the time.
   @time = localtime time;
-  $ts = sprintf ('%02u%02u%02u %02u:%02u:%02u(%u)',
-    $time[5], $time[4]+1, $time[3], $time[2], $time[1], $time[0], $$);
+  $ts = sprintf ('%04u-%02u-%02u %02u:%02u:%02u (%u)',
+    $time[5] += 1900, $time[4]+1, $time[3], $time[2], $time[1], $time[0], $$);
   print LOG_FILE $ts, $msg;
 }
 


### PR DESCRIPTION
Ever since the year 2000, the timestamps in the oanda_server.pl's log file have shown dates with a leading 1, like "1200901", where "120" means "120 years since 1900."

This change converts the log timestamps to proper four-digit years, like "2020-09-01".