### PR TITLE
Fix typos in tprint.cat

### DIFF
--- a/Morsulus-Search/scripts/tprint.cat
+++ b/Morsulus-Search/scripts/tprint.cat
@@ -2643,7 +2643,6 @@ head, beast, goat
 head, beast, horse
 head, beast, marten
 head, beast, rabbit
-head, rat
 head, beast, skull
 head, beast, other
 head, bird


### PR DESCRIPTION
Commit 8d0bc28fa1 introduced a few typos in tprint.cat

- Line added for "armica" -- should be "arnica"

- Line added for "cucumbercup" -- should be two lines, "cucumber" and "cup"

- Line added for "head, beast, rat" -- but what was added to temp.cat was "rat's head - see head, beast, other" for which we already have an entry in tprint.cat -- so maybe we don't need this at all?