### PR TITLE
Corrected documentation of limit feature

### DIFF
--- a/Morsulus-Search/config.web
+++ b/Morsulus-Search/config.web
@@ -1230,15 +1230,16 @@ The <a href="XXNpSearchUrlXX">name pattern search form</a>,
 and <a href="XXComplexSearchUrlXX">complex search form</a>
 each allow you to set a limit on the number of returned items.
 On these forms, if you do not specify a limit, your results will be limited
-to 25 items.
+to 500 items.
 
 <p>
-If your search is limited, you will see a message such as:
+If your search is limited, you will see a message at the bottom of your results listing similar to the below:
 <blockquote>
 <p>There were <em>n</em> other items for which details are not
 available, due to the <a href="XXLimitPageUrlXX">limit feature</a>.
 </blockquote>
-at the bottom of your results listing.  In this case, the item
+<p>
+    In this case, the item
 you were looking for may be one of the ones that was cut from
 the listing.  There are several things you might do next:
 <ul>
@@ -14612,7 +14613,7 @@ $conf_file = '.configweb';
 
 $config{'XXPrimerUrlXX'} = 'http://heraldry.sca.org/armory/newprimer/';
 $config{'XXLoARUrlXX'} = 'http://heraldry.sca.org/loar';
-$config_version = '2022-12-16 (1:127+)';
+$config_version = '2021-02-14 (mathghamhain:development:179+)';
 $config{'XXVersionXX'} = $config_version;
 $config{'XXHeadXX'} = '';
 

--- a/Morsulus-Search/scripts/hints_bp.html
+++ b/Morsulus-Search/scripts/hints_bp.html
@@ -78,10 +78,8 @@ treat "O" and "o" as being the same, so that "or" would match both
 <h3>Maximum Number of Items to Display</h3>
 <p>
 You can control the size of your search result by typing a number
-of items (1-500) in this box.  If you do not fill in the box, at most
-25 items will be displayed.  Note that there is a
-<a href="XXLimitPageUrlXX">built-in limit</a>
-of 500 items, which you cannot override.
+of items in this box.  If you do not fill in the box, at most
+500 items will be displayed.  If more than this number of items match your criteria, you will see a notice linking to <a href="XXLimitPageUrlXX">an explanation of the limit feature</a>.
 <p>
 <h3>Display Options</h3>
 <p>

--- a/Morsulus-Search/scripts/hints_complex.html
+++ b/Morsulus-Search/scripts/hints_complex.html
@@ -70,10 +70,8 @@ There are currently four methods available for specifying criteria:
 <h3>Maximum Number of Items to Display</h3>
 <p>
 You can control the size of your search result by typing a number
-of items (1-500) in this box.  If you do not fill in the box, at most
-25 items will be displayed.  Note that there is a
-<a href="XXLimitPageUrlXX">built-in limit</a>
-of 500 items, which you cannot override.
+of items in this box.  If you do not fill in the box, at most
+500 items will be displayed.  If more than this number of items match your criteria, you will see a notice linking to <a href="XXLimitPageUrlXX">an explanation of the limit feature</a>.
 <p>
 <h3>Display Options</h3>
 <p>

--- a/Morsulus-Search/scripts/hints_date.html
+++ b/Morsulus-Search/scripts/hints_date.html
@@ -28,10 +28,8 @@ next to the Kingdom's name.
 <h3>Maximum Number of Items to Display</h3>
 <p>
 You can control the size of your search result by typing a number
-of items (1-500) in this box.  If you do not fill in the box, at most
-25 items will be displayed.  Note that there is a
-<a href="XXLimitPageUrlXX">built-in limit</a>
-of 500 items, which you cannot override.
+of items in this box.  If you do not fill in the box, at most
+500 items will be displayed.  If more than this number of items match your criteria, you will see a notice linking to <a href="XXLimitPageUrlXX">an explanation of the limit feature</a>.
 <p>
 <h3>Display Options</h3>
 <p>

--- a/Morsulus-Search/scripts/hints_np.html
+++ b/Morsulus-Search/scripts/hints_np.html
@@ -97,10 +97,8 @@ treat "A" and "a" as being the same, so that "And" would match both
 <h3>Maximum Number of Items to Display</h3>
 <p>
 You can control the size of your search result by typing a number
-of items (1-500) in this box.  If you do not fill in the box, at most
-25 items will be displayed.  Note that there is a
-<a href="XXLimitPageUrlXX">built-in limit</a>
-of 500 items, which you cannot override.
+of items in this box.  If you do not fill in the box, at most
+500 items will be displayed.  If more than this number of items match your criteria, you will see a notice linking to <a href="XXLimitPageUrlXX">an explanation of the limit feature</a>.
 <p>
 <h3>Display Options</h3>
 <p>

--- a/Morsulus-Search/scripts/search_limits.html
+++ b/Morsulus-Search/scripts/search_limits.html
@@ -11,15 +11,16 @@ The <a href="XXNpSearchUrlXX">name pattern search form</a>,
 and <a href="XXComplexSearchUrlXX">complex search form</a>
 each allow you to set a limit on the number of returned items.
 On these forms, if you do not specify a limit, your results will be limited
-to 25 items.
+to 500 items.
 
 <p>
-If your search is limited, you will see a message such as:
+If your search is limited, you will see a message at the bottom of your results listing similar to the below:
 <blockquote>
 <p>There were <em>n</em> other items for which details are not
 available, due to the <a href="XXLimitPageUrlXX">limit feature</a>.
 </blockquote>
-at the bottom of your results listing.  In this case, the item
+<p>
+    In this case, the item
 you were looking for may be one of the ones that was cut from
 the listing.  There are several things you might do next:
 <ul>


### PR DESCRIPTION
There are several places in the documentation that suggest that the search result limit defaults to 25, or that there is a hard-coded maximum of 500 which can not be exceeded.

Both of these numbers were changed in previous releases, so this change brings the documentation up to date.